### PR TITLE
Increase password hash strength

### DIFF
--- a/cms/includes/functions.admin.inc.php
+++ b/cms/includes/functions.admin.inc.php
@@ -7,9 +7,11 @@
  */
 function generate_pw_hash($pw)
  {
-  $salt = random_string(10,'0123456789abcdef');
-  $salted_hash = sha1($pw.$salt);
-  $hash_with_salt = $salted_hash.$salt;
+  #$salt = random_string(10,'0123456789abcdef');
+  #$salted_hash = sha1($pw.$salt);
+  #$hash_with_salt = $salted_hash.$salt;
+  $salt = random_string(16);
+  $hash_with_salt = crypt($pw, '$6$rounds=5000$'.$salt.'$');
   return $hash_with_salt;
  }
 
@@ -29,6 +31,7 @@ function is_pw_correct($pw,$hash)
     if(sha1($pw.$salt)==$salted_hash) return true;
     else return false;
    }
+  elseif(crypt($pw, $hash) == $hash) return true;
   else return false;
  }
 


### PR DESCRIPTION
This pull request proposes the use of the de-facto standard of password hashing used by many Linux distributions. This makes cracking attempts way more costy. Strength depends on the number of hashing rounds which is configurable by adjusting the "rounds=5000" substring on line 14. The more rounds, the stronger the resulting hash.
- altered generate_pw_hash to produce SHA-512 hashes (unix type 6)
- altered is_pw_correct to check against the old and against the new hashes. Backward compatibility is preserved.
